### PR TITLE
KUNST-47: Locked "runs-on" to ubuntu 18.04

### DIFF
--- a/.github/workflows/deployment_dev.yml
+++ b/.github/workflows/deployment_dev.yml
@@ -9,7 +9,7 @@ name: Deployment (dev)
 jobs:
   build:
     name: Build and deploy assets (dev)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@master
 
@@ -40,7 +40,7 @@ jobs:
   deploy:
     name: Deploy Application (dev)
     needs: build
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Run remote commands
         uses: itk-dev/actions-remote-ssh@master

--- a/.github/workflows/deployment_prod.yml
+++ b/.github/workflows/deployment_prod.yml
@@ -9,7 +9,7 @@ name: Deployment (prod)
 jobs:
   build:
     name: Build and deploy assets (prod)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - uses: actions/checkout@master
 
@@ -40,7 +40,7 @@ jobs:
   remote:
     needs: build
     name: Deploy Application (prod)
-    runs-on: ubuntu-latest
+    runs-on: ubuntu-18.04
     steps:
       - name: Run remote commands
         uses: itk-dev/actions-remote-ssh@master

--- a/.github/workflows/pr.yaml
+++ b/.github/workflows/pr.yaml
@@ -3,7 +3,7 @@ name: Review
 jobs:
     test-composer-files:
         name: Validate composer (PHP ${{ matrix.php }})
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         strategy:
             fail-fast: false
             matrix:
@@ -29,7 +29,7 @@ jobs:
 
     runner-phpcs:
         name: runner-phpcs (PHP ${{ matrix.php }})
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         strategy:
             fail-fast: false
             matrix:
@@ -61,7 +61,7 @@ jobs:
 
     phpcsfixer:
         name: PHP-CS-FIXER (PHP ${{ matrix.php }})
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         strategy:
             fail-fast: false
             matrix:
@@ -89,7 +89,7 @@ jobs:
 
     twigcs:
         name: TwigCS (PHP ${{ matrix.php }})
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         strategy:
             fail-fast: false
             matrix:
@@ -117,7 +117,7 @@ jobs:
 
     js-coding-standards:
         name: JS coding standards
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         steps:
             - uses: actions/checkout@master
             - uses: actions/setup-node@v1
@@ -130,7 +130,7 @@ jobs:
 
     test-yarn-build:
         name: Test yarn build assets
-        runs-on: ubuntu-latest
+        runs-on: ubuntu-18.04
         steps:
             - uses: actions/checkout@master
 


### PR DESCRIPTION
Deploy fails with `Error loading key "/root/.ssh/id_rsa": invalid format` on Ubuntu 20.04